### PR TITLE
feat: Scan QR code from Image functionality

### DIFF
--- a/wifi-qr
+++ b/wifi-qr
@@ -190,9 +190,13 @@ call_zbar_cam_scan() {
   # Last job running in background eg. zbarcam
   pid=$!
   # Sleep loop until $qr_data file has content
+  local i=0
+  local chars="/-\|"
+  echo -en "  Scanning QR Code" "\r"
   while [[ ! -s $qr_data ]]; do
-    sleep 1
-    pgrep -x zbarcam >/dev/null && echo "Still Scanning" || exit 0
+    sleep 0.5
+    pgrep -x zbarcam >/dev/null && echo -en "${chars:$i:1}" "\r" || exit 0
+    i=$(((i+1)%${#chars}))
     # cleanup - add a trap that will remove $qr_data and kill zbarcam
     # if any of the signals - SIGHUP SIGINT SIGTERM it received.
     trap 'rm -f "$qr_data" ; kill -s 9 "$pid"; exit' SIGHUP SIGINT SIGTERM

--- a/wifi-qr
+++ b/wifi-qr
@@ -30,8 +30,8 @@ VERSION=0.2
 
 #RAW DATA SAMPLE
 #"WIFI:S:$SSID;P:$PASSWORD;T:$KEY_TYPE;H:$true;"
-#qrencode -o - -t UTF8 
-#qrencode -l h -s 14 -o 
+#qrencode -o - -t UTF8
+#qrencode -l h -s 14 -o
 
 #GUI Mainmenu
 main_menu() {
@@ -43,6 +43,7 @@ main_menu() {
     --width=300 --height=320 \
     --column="Check" --column="Option" \
     TRUE "Scan and connect" \
+    FALSE "Scan Image and connect" \
     FALSE "Share current WiFi" \
     FALSE "Share saved WiFi" \
     FALSE "See license" \
@@ -54,9 +55,12 @@ main_menu() {
 
   elif [[ "$CHOICE" =~ "Share current WiFi" ]]; then
     call_current_wifi_gui
-  
+
   elif [[ "$CHOICE" =~ "Scan and connect" ]]; then
-    call_wifi_scan_gui
+    call_wifi_scan_gui "cam"
+
+  elif [[ "$CHOICE" =~ "Scan Image and connect" ]]; then
+    call_file_select_and_scan_gui
 
   elif [[ "$CHOICE" =~ "See license" ]]; then
     zenity --text-info --title="WiFi QR Copyright" --filename=/usr/share/doc/wifi-qr/copyright --width=528 --height=780
@@ -139,7 +143,7 @@ call_wifi_terminal() {
 terminal_qr() {
   call_wifi_pass
   qrencode -o - -t UTF8 "WIFI:S:$WIFIS;P:$KEEY;$PSSK$H;"
-  echo 
+  echo
 }
 
 current_wifi_ssid() {
@@ -179,16 +183,12 @@ call_wifi_pass() {
   echo -e "${RESET}"
 }
 
-call_wifi_scan() {
-  wifiqrdata=''
-  # tmp data-matrix holder
-  cwd="/tmp/"
-  qr_data="$cwd/wifi-qr-scan"
-  zbarcam --raw --prescale=320x240 /dev/video0 >$qr_data &
+call_zbar_cam_scan() {
+  qr_data=$1
+  zbarcam --raw --prescale=320x240 /dev/video0 >"$qr_data" &
 
   # Last job running in background eg. zbarcam
   pid=$!
-
   # Sleep loop until $qr_data file has content
   while [[ ! -s $qr_data ]]; do
     sleep 1
@@ -199,6 +199,30 @@ call_wifi_scan() {
   done
 
   kill -s 9 $pid
+  # to supress the kill message
+  # https://stackoverflow.com/a/5722874/11910267
+  wait $pid 2>/dev/null
+}
+
+call_zbar_img_scan() {
+  qr_data=$1
+  img_path=$2
+  zbarimg --raw "$img_path" >"$qr_data" 2>/dev/null
+}
+
+call_wifi_scan() {
+  mode=$1
+  wifiqrdata=''
+  # tmp data-matrix holder
+  cwd="/tmp/"
+  qr_data="$cwd/wifi-qr-scan"
+
+  if [[ $mode == "cam" ]]; then
+    call_zbar_cam_scan "$qr_data"
+  else
+    call_zbar_img_scan "$qr_data" "$mode" # mode stores the image path
+  fi
+
   wifiqrdata=$(cat $qr_data)
   rm -f $qr_data
 
@@ -207,7 +231,7 @@ call_wifi_scan() {
     ## Go Go GUI and CLI Mod
     # ssid & key are not always in the same sequence - fix by using a dict and cut identifier for first key
     if echo "$wifiqrdata" | grep --quiet "H:true;"; then
-    	QHIDE=true 
+    	QHIDE=true
     fi
     declare -A wifiqrcred
     wifiqrcred+=([$(echo "$wifiqrdata" | cut -b 6- | awk -F';' '{print $1}' | cut -d":" -f1)]=$(echo "$wifiqrdata" | cut -b 6- | awk -F';' '{print $1}' | cut -d":" -f2))
@@ -268,7 +292,7 @@ call_wifi_scan() {
 
 
 call_wifi_scan_terminal() {
-  call_wifi_scan
+  call_wifi_scan "$1"
      if [[ "$QSSIDO" == "NOWIFI" ]]; then
 	exit 0
      elif [[ "$QHIDE" == "true" ]]; then
@@ -282,10 +306,10 @@ call_wifi_scan_terminal() {
 }
 
 call_wifi_scan_gui() {
-  call_wifi_scan
+  call_wifi_scan "$1"
   # Function with QR data
   if [[ "$QSSIDO" =~ "ON" ]]; then
-    zenity --question --title="Connect to WiFi" --text="Connect to '$QSSID'?" --width=200 --height=120 --icon-name=network-wireless 2>/dev/null 
+    zenity --question --title="Connect to WiFi" --text="Connect to '$QSSID'?" --width=200 --height=120 --icon-name=network-wireless 2>/dev/null
     connectn=$?
     if [ $connectn == 0 ]; then \
       scan_connect
@@ -314,7 +338,11 @@ call_wifi_scan_gui() {
         exit
       fi
     elif [[ "$CHOICE" =~ "Retry submitting another QR Code" ]]; then
-      call_wifi_scan_gui
+      if [[ $1 == "cam" ]]; then
+        call_wifi_gui "cam"
+      else
+        call_file_select_and_scan_gui
+      fi
     else
       exit
     fi
@@ -326,6 +354,15 @@ call_wifi_scan_gui() {
       exit
     fi
   fi
+}
+
+call_file_select_and_scan_gui () {
+  img_path=$(zenity --file-selection)
+  if [ -z "$img_path" ]; then
+    echo "No file selected"
+    exit
+  fi
+  call_wifi_scan_gui "$img_path"
 }
 
 scan_connect() {
@@ -360,11 +397,20 @@ case $1 in
   ;;
 [Ss])
   echo "qr scan"
-  call_wifi_scan_terminal
+  call_wifi_scan_terminal "cam"
+  ;;
+[Ff])
+  if [ -f "$2" ]; then
+    echo "qr scan from file $2"
+    call_wifi_scan_terminal "$2"
+  else
+    echo "File not found"
+    exit
+  fi
   ;;
 [Qq])
   echo "qr scan with gui"
-  call_wifi_scan_gui
+  call_wifi_scan_gui "cam"
   ;;
 [Vv])
    echo -e "${GREEN}==================${RESET}"
@@ -373,10 +419,11 @@ case $1 in
   ;;
 *)
   echo -e "\nInvalid input\n
-	Please use	g for GUI Main Menu 
+	Please use	g for GUI Main Menu
 			c for WiFi QR Create GUI
 			t for WiFi QR Create Terminal
 			s for QR Scan and Auto Connect WiFi
+			f [file] for QR Scan and Auto Connect WiFi from file
 			q for QR Scan and Connect WiFi GUI
 			v for WiFi-QR Version is $VERSION
 		"


### PR DESCRIPTION
Fixes #10 

## GUI Version

There is a new option in the GUI to **"Scan Image and connect"**

![image](https://user-images.githubusercontent.com/51032928/164715166-be0514cd-8d4c-4750-9688-927da11c43a3.png)

Selecting it opens the file selection window done with `zenity --file-selection`. Once the user selects the image, the function `call_zbar_img_scan` is called which scans the image for the data and stores it in the `qr_data`. 

```bash
call_zbar_img_scan() {
  qr_data=$1
  img_path=$2
  zbarimg --raw "$img_path" >"$qr_data" 2>/dev/null
}
```

## Terminal Version

Here, there is an option `f` and the user has to provide the path of the image along with it.

![image](https://user-images.githubusercontent.com/51032928/164716127-bb72cf7c-74ff-46c4-8f5e-c70a21e3c44f.png)

---

Initially while scanning from the terminal it would print "Still Scanning" in a new line repeatedly. With 359950a8d4affb857eeb938f68919203378fcad3 it would replace it with a loader animation. 

[![asciicast](https://asciinema.org/a/OUqYsXuyV9kd8A2JqN9FLkr7D.svg)](https://asciinema.org/a/OUqYsXuyV9kd8A2JqN9FLkr7D)